### PR TITLE
Nontemporal proposed semantics

### DIFF
--- a/docs/xlang/exprs/access-class.md
+++ b/docs/xlang/exprs/access-class.md
@@ -40,9 +40,17 @@
 
 15. [Note: As long as the above rules are maintained, relaxed atomic loads may be reordered freely, and merged into adjacent relaxed loads.]
 
-## Non-temporal
+## Non-temporal [expr.nontemporal]
 
 `class-option := nontemporal`
 
 1. An access class may contain the `nontemporal` specifier. 
+
+2. An access may not specify both the `nontemporal` access class and an atomic access class.
+
+3. [Note: Fences and sequence instructions may specify both simultaneously]
+
+4. `nontemporal` accesses do not guarantee visibility order with respect to accesses to other memory locations.
+
+5. [Note: Nontemporal accesses are intended to hint to the processor that the program is unlikely to use the data loaded/stored in the future]
 

--- a/docs/xlang/exprs/access-class.md
+++ b/docs/xlang/exprs/access-class.md
@@ -39,3 +39,10 @@
 14. The implementation should ensure that atomic stores on one thread of execution become visible to a load from the same object on another thread of execution in finite time. 
 
 15. [Note: As long as the above rules are maintained, relaxed atomic loads may be reordered freely, and merged into adjacent relaxed loads.]
+
+## Non-temporal
+
+`class-option := nontemporal`
+
+1. An access class may contain the `nontemporal` specifier. 
+

--- a/docs/xlang/memory.md
+++ b/docs/xlang/memory.md
@@ -2,15 +2,24 @@
 
 1. XLang Programs execute according to a partial order, defined in the following sections. This order guarantees that single-threaded programs that do not handle signals execute in as-written order according to the xlang specification. 
 
-2. There are 3 binary relations defined by the xlang specification, given below. Each of these relations are Asymetric, and are transitive other than "weekly happens-before"
-    * The sequenced-before relation describes the order of single-threaded programs. For two expressions on the same thread of execution, E and F, either E is sequenced-before F, F is sequenced-before E, E and F are the same expression, or at least one of E and F executes from an asynchronous signal handler and the other does not execute from the same asynchronous signal handler.
-        * [Note: In a single-threaded program, without signal handlers, this relation is equivalent to the weekly happens-before and happens-before relation]
-    * The weekly happens-before relation is one of two relations that describes the order of a multi-threaded program. If two expression E and F exist, such that E *happens-before* F, then E *weekly happens-before* F. 
-    * The happens-before relation is the second relation that describe the order of a multithreaded program. If two expression E and F exist, such that E is *sequenced-before* F, then E *happens-before* F. The happens-before relation is established between threads by synchronization edges.
-    * [Note: in a single-threaded program, all three of these relations are equivalent]
+## Execution Ordering [memory.execution]
 
-3. Certain expression *synchronize-with* other expression. These expressions guarantee that a happens-before relation exists between these expressions in some order (which order is unspecified, unless otherwise guaranteed). 
+1. There are a number of partial order relations that establish the order of execution of an xlang program. These are defined here. Each partial order is Assymetric.
 
+2. The *weakly sequenced-before* relation describes the expresion order of a single thread. For each pair of expressions E and F, which are executed within a particular thread, such that either E and F are both not executed by a signal handler, or are both executed by the same signal handler, either E and F are the same expression, E is *weakly sequenced-before* F, or F is *weakly sequenced-before* E The *weakly sequenced-before* relation is transitive.  Thus, for three expressions A, B, and C, if A is *weakly sequenced-before* B and B is *weakly sequenced-before* C, then A is *weakly sequenced-before* C.
+3. A *weakly sequenced-before* relation is precisely defined as program order as evaluated (considering branches, function calls, and block exits). 
+4. The *sequenced-before* relation describes the memory access order of expressions on a single thread. The *sequenced-before* relation is transitive. Thus, for three expressions A, B, and C, if A is *sequenced-before* B and B is *sequenced-before* C, then A is *sequenced-before* C.
+5. The *sequenced-before* relation is established as follows, between two expressions A and B if:
+    - Neither A nor B are accesses with the `nontemporal` access class, and A is *weakly sequenced-before* B,
+    - A and B are both access to the same memory location, and A is *weakly sequenced-before* B,
+    - A is an access with the `nontemporal` access class, and B is a fence or sequence expression with the `nontemporal` access class, and A is *weakly sequenced-before* B, or
+    - B is an access with the `nontemporal` access class, and A is a fence or sequence expression with the `nontemporal` access class, and A is *weakly sequeneced-before* B.
+6. [Note: Absent nontemporal accesses, *weakly sequenced-before* is equivalent to *sequenced-before*. *weakly sequenced-before* describes the order of behaviour of an xlang program, *sequenced-before* describes the order that memory accesses become visible within a thread of execution]
+7. The *happens-before* relation describes the order of expressions accross the entire program, including between two threads and between a thread and a signal handler. The *happens-before* relation is transitive. Thus, for three expressions A, B, and C, if A is *sequenced-before* B and B is *sequenced-before* C, then A is *sequenced-before* C.
+8. An Expression A *happens-before* an expression B if:
+    - A is *sequenced-before* B,
+    - A *synchronizes-with* B. 
+9. [Note: Absent signal handlers, on a single-threaded program, *happens-before* and *sequenced-before* are identical]
 
 ## Object Model [memory.object]
 


### PR DESCRIPTION
This adds a specification for the `nontemporal` access class.

The `nontemporal` access class has two primary behaviours:
* Hints that caching the value loaded/stored is unnecessary
* Alters ordering semantics s.t. visibility wrt. other memory locations is not guaranteed (and a `nontemporal` fence is required in order to synchronize nontemporal operations).